### PR TITLE
home.html: Updates home.html and creates sidebar-item.html.

### DIFF
--- a/_includes/git-wiki/components/sidebar/sidebar-item.html
+++ b/_includes/git-wiki/components/sidebar/sidebar-item.html
@@ -1,0 +1,52 @@
+{% assign normalized_page_url = page_url | append: "/" %}
+{% assign normalized_item_url = item.url | append: "/" %}
+{% assign should_open = false %}
+
+{% if item.children %}
+  {% for child in item.children %}
+    {% assign normalized_child_url = child.url | append: "/" %}
+    {% if normalized_page_url == normalized_child_url %}
+      {% assign should_open = true %}
+    {% endif %}
+    {% if child.children %}
+      {% for grandchild in child.children %}
+        {% assign normalized_grandchild_url = grandchild.url | append: "/" %}
+        {% if normalized_page_url == normalized_grandchild_url %}
+          {% assign should_open = true %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+<li class="nav-item{% if item.collapsible %} collapsible{% endif %}">
+  {% if item.children and item.collapsible %}
+    <details {% if should_open %}open{% endif %}>
+      <summary>
+        {% if item.url %}
+          <a href="{{ site.baseurl }}{{ item.url }}" class="nav-link{% if normalized_page_url == normalized_item_url %} active{% endif %}">
+            {{ item.title }}
+          </a>
+        {% else %}
+          {{ item.title }}
+        {% endif %}
+      </summary>
+      <ul class="nav-sublist">
+        {% for child in item.children %}
+          {% include sidebar-item.html item=child page_url=page_url %}
+        {% endfor %}
+      </ul>
+    </details>
+  {% elsif item.children %}
+    <span class="nav-header">{{ item.title }}</span>
+    <ul class="nav-sublist">
+      {% for child in item.children %}
+        {% include sidebar-item.html item=child page_url=page_url %}
+      {% endfor %}
+    </ul>
+  {% else %}
+    <a href="{{ site.baseurl }}{{ item.url }}" class="nav-link{% if normalized_page_url == normalized_item_url %} active{% endif %}">
+      {{ item.title }}
+    </a>
+  {% endif %}
+</li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,52 +15,7 @@
         <nav class="sidebar-nav">
           <ul class="nav-list">
             {% for item in site.data.navigation %}
-              {% assign should_open = false %}
-              {% if item.children %}
-                {% for child in item.children %}
-                  {% assign normalized_page_url = page.url | append: "/" %}
-                  {% assign normalized_child_url = child.url | append: "/" %}
-                  {% if normalized_page_url == normalized_child_url %}
-                    {% assign should_open = true %}
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
-
-              {% if item.children and item.collapsible %}
-                <li class="nav-item collapsible">
-                  <details {% if should_open %}open{% endif %}>
-                    <summary>{{ item.title }}</summary>
-                    <ul class="nav-sublist">
-                      {% for child in item.children %}
-                        <li class="nav-subitem">
-                          <a href="{{ site.baseurl }}{{ child.url }}" class="nav-sublink{% if page.url == child.url %} active{% endif %}">
-                            {{ child.title }}
-                          </a>
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  </details>
-                </li>
-              {% elsif item.children %}
-                <li class="nav-item">
-                  <span class="nav-header">{{ item.title }}</span>
-                  <ul class="nav-sublist">
-                    {% for child in item.children %}
-                      <li class="nav-subitem">
-                        <a href="{{ site.baseurl }}{{ child.url }}" class="nav-sublink{% if page.url == child.url %} active{% endif %}">
-                          {{ child.title }}
-                        </a>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </li>
-              {% else %}
-                <li class="nav-item">
-                  <a href="{{ site.baseurl }}{{ item.url }}" class="nav-link{% if page.url == item.url %} active{% endif %}">
-                    {{ item.title }}
-                  </a>
-                </li>
-              {% endif %}
+              {% include git-wiki/components/sidebar/sidebar-item.html item=item page_url=page.url %}
             {% endfor %}
           </ul>
         </nav>


### PR DESCRIPTION
Simplifies home.html by offloading sidebar code to ensure that the theme remains modular and so that home.html remains easier to audit and maintain. Adds sidebar-item.html to newly created /sidebar/ in  _includes/git-wiki/components/ to ensure that the sidebar.html is more discoverable and aligned with the existing taxonomy of the UI components inside /components/. To extend sidebar nesting, update includes/git-wiki/components/sidebar/sidebar-item.html. Currently, this partial supports collapsible sections, active link highlighting, and recursive rendering of children.